### PR TITLE
fix favicon not showing v2

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
     
     <!-- Lenis Smooth Scroll -->
     <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.19/bundled/lenis.min.js"></script>
-    <link rel="icon" type="image/x-icon" href="/src/img/icon.ico?">
+    <link rel="icon" type="image/x-icon" href="./src/img/icon.ico?">
 
     <script src="script.js"></script>
 </head>


### PR DESCRIPTION
fix
had to add '.' before the path of the favicon and an '?' at the end